### PR TITLE
Removed the "is_unavailable" field to avoid crashes

### DIFF
--- a/src/responses/update.rs
+++ b/src/responses/update.rs
@@ -61,7 +61,6 @@ pub struct Message {
     pub id: i32,
     pub important: bool,
     pub is_hidden: bool,
-    pub is_unavailable: bool,
     pub out: i32,
     pub peer_id: i32,
     pub random_id: i32,


### PR DESCRIPTION
Delete is_unavailable from Message struct.
I check the vk api docs and dont see any mentions about this field in message data type.

Maybe api provide is_unavailable only with true value. Even if this is the case, it is better to remove these fields to restore the library's functionality